### PR TITLE
Consolidate properties at project level

### DIFF
--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="Encoding" addBOMForNewFiles="with NO BOM" />
-</project>

--- a/README.md
+++ b/README.md
@@ -1,23 +1,23 @@
-#NetHunter Terminal Emulator
+# NetHunter Terminal Emulator
 
-This is a new fork of the Android Terminal Emulator so we can adapt it to our neeeds for Kali Linux Nethunter.
+This is a new fork of the Android Terminal Emulator so we can adapt it to our neeeds for Kali NetHunter.
 
 Dependencies running the terminal:
 
-    Nedds a full instalation (included the chroot install) of Kali Nethunter
+    Needs a full installation of Kali NetHunter (including chroot) 
 
 
 
-Buiding from sources:
+Building from sources:
 
 (Todo) see: https://github.com/jmingov/NetHunter-Terminal-Emulator/blob/master/docs/Building.md
 
 
-Since the original proyect is "ended" we left here the credits an licenses:
+Since the original project has "ended" we'll include the credits and licenses below:
 
 
 Original author: https://github.com/jackpal
 
-Original proyect: https://github.com/jackpal/Android-Terminal-Emulator
+Original project: https://github.com/jackpal/Android-Terminal-Emulator
 
-License: The same as the original proyect. (Thouse files are [included](https://github.com/jmingov/NetHunter-Terminal-Emulator/blob/master/NOTICE) in this proyect too.)
+License: The same as the original project. (Thouse files are [included](https://github.com/jmingov/NetHunter-Terminal-Emulator/blob/master/NOTICE) in this project too.)

--- a/build.gradle
+++ b/build.gradle
@@ -7,9 +7,10 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.0-alpha09'
+        classpath 'com.android.tools.build:gradle:3.2.0'
     }
 }
+
 
 allprojects {
     repositories {
@@ -17,3 +18,11 @@ allprojects {
         google()
     }
 }
+
+ext {
+    compileSdkVersion=28
+    minSdkVersion=14
+    targetSdkVersion=28
+    versionName="2019.2-rc1"
+}
+

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,8 @@ ext {
     compileSdkVersion=28
     minSdkVersion=14
     targetSdkVersion=28
-    versionName="2019.2-rc1"
+    //version=YYYYMMVVRR (Either "VV" for stable version OR "RR" for pre-release candidate (e.g. 0001 for rc1)
+    versionCode=2019020002
+    versionName="2019.2-rc2"
 }
 

--- a/emulatorview/build.gradle
+++ b/emulatorview/build.gradle
@@ -6,6 +6,7 @@ android {
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
+        versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
     }
 

--- a/emulatorview/build.gradle
+++ b/emulatorview/build.gradle
@@ -1,11 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion rootProject.ext.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion 4
-        targetSdkVersion 28
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
+        versionName rootProject.ext.versionName
     }
 
     buildTypes {

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,3 +13,4 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 #Fri Sep 16 18:00:52 CDT 2016
+

--- a/libtermexec/build.gradle
+++ b/libtermexec/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.0-alpha09'
+        classpath 'com.android.tools.build:gradle:3.2.0'
     }
 }
 apply plugin: 'com.android.library'
@@ -19,6 +19,7 @@ android {
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
+        versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
 
 

--- a/libtermexec/build.gradle
+++ b/libtermexec/build.gradle
@@ -14,13 +14,13 @@ repositories {
 }
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion rootProject.ext.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion 14
-        targetSdkVersion 28
-        versionCode 2
-        versionName "2.0"
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
+        versionName rootProject.ext.versionName
+
 
         ndk {
             moduleName 'libjackpal-termexec2'

--- a/term/build.gradle
+++ b/term/build.gradle
@@ -7,6 +7,7 @@ android {
         applicationId 'com.offsec.nhterm'
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
+        versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
 
         ndk {

--- a/term/build.gradle
+++ b/term/build.gradle
@@ -1,11 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion rootProject.ext.compileSdkVersion
+
     defaultConfig {
         applicationId 'com.offsec.nhterm'
-        minSdkVersion 26
-        targetSdkVersion 28
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
+        versionName rootProject.ext.versionName
 
         ndk {
             moduleName "libjackpal-androidterm5nhj1"

--- a/term/src/main/java/com/offsec/nhterm/TermService.java
+++ b/term/src/main/java/com/offsec/nhterm/TermService.java
@@ -152,6 +152,9 @@ public class TermService extends Service implements TermSession.FinishCallback
 
     @Override
     public void onDestroy() {
+        // invoking notificationManager.cancel on Android < 8 causes a null pointer exception so we should check first
+        if (notificationManager == null)
+            notificationManager = (NotificationManager)  getSystemService(NOTIFICATION_SERVICE);
         // Remove notification
         notificationManager.cancel(notifyID);
 


### PR DESCRIPTION
Define common properties at project level:
    compileSdkVersion=28
    minSdkVersion=14
    targetSdkVersion=28
    versionName="2019.2-rc1"

Downgrade gradle version requirements to 3.2

The above fixes the problem that the app only runs on >=Oreo. One of the modules gradle,build had a wrong minSdkVersion. Shouldn't happen in the future anymore.
The app seems to work well but it terminates not in the most graceful manner, i.e. it throws a "NetHunter Terminal has stopped" error. Is it working for you?